### PR TITLE
Add deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Letta TypeScript API Library
 
+> [!WARNING]
+> **This package is deprecated.** New development should use the [Letta Agent SDK](https://github.com/letta-ai/letta-agent-sdk) ([documentation](https://docs.letta.com/agent-sdk)) instead. The Agent SDK provides high-level primitives for stateful agents — sessions, streaming, permissions, and skills — and is the supported path for the current Letta platform. This package is unmaintained and receives no new features.
+
 [![NPM version](<https://img.shields.io/npm/v/@letta-ai/letta-client.svg?label=npm%20(stable)>)](https://npmjs.org/package/@letta-ai/letta-client) ![npm bundle size](https://img.shields.io/bundlephobia/minzip/@letta-ai/letta-client)
 
 This library provides convenient access to the Letta REST API from server-side TypeScript or JavaScript.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Letta TypeScript API Library
 
 > [!WARNING]
+>
 > **This package is deprecated.** New development should use the [Letta Agent SDK](https://github.com/letta-ai/letta-agent-sdk) ([documentation](https://docs.letta.com/agent-sdk)) instead. The Agent SDK provides high-level primitives for stateful agents — sessions, streaming, permissions, and skills — and is the supported path for the current Letta platform. This package is unmaintained and receives no new features.
 
 [![NPM version](<https://img.shields.io/npm/v/@letta-ai/letta-client.svg?label=npm%20(stable)>)](https://npmjs.org/package/@letta-ai/letta-client) ![npm bundle size](https://img.shields.io/bundlephobia/minzip/@letta-ai/letta-client)


### PR DESCRIPTION
## tl;dr

New users are still picking up `@letta-ai/letta-client` because no public surface marks it deprecated. This adds a README banner stating the package is deprecated and pointing to the [Letta Agent SDK](https://github.com/letta-ai/letta-agent-sdk) ([docs](https://docs.letta.com/agent-sdk)) as the replacement. The README is consumed both as the GitHub README and as the docs.letta.com/api/typescript page content, so one banner covers both. The v1 SDK deprecation is already stated at https://docs.letta.com/v1-sdk.

## Review notes

- The banner intentionally sits above the badges so it is the first thing read.
- This does not change any code or the published package version. Marking the npm package itself with `npm deprecate` is a separate registry action for a Letta team member with npm publish rights, not something this repo PR can do. A runtime deprecation warning on import is a possible follow-up but is a behavioral change beyond this README fix.

## Testing

No automated test is meaningful for this change; verified that the README renders as valid Markdown with the GitHub alert syntax.

## Breadcrumbs

- Requested by: Sarah Wooders (Slack, #software-factory)
- Letta conversation: [`conv-ee3c8d0a-7ed4-414d-b4eb-a501ea9b426c`](https://chat.letta.com/chat/agent-19babcc0-e958-41b0-81d8-00107f71deb7?conversation=conv-ee3c8d0a-7ed4-414d-b4eb-a501ea9b426c)
- Related: letta-ai/skills#90 (removes the skill that teaches this package), letta-ai/letta-python#95 (Python counterpart)